### PR TITLE
Add workflow to build all C++ solutions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,35 @@
+name: Build C++ solutions
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        compiler: [g++, clang++]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install g++-13
+        if: matrix.compiler == 'g++'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y g++-13
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 100
+      - name: Install clang
+        if: matrix.compiler == 'clang++'
+        run: sudo apt-get update && sudo apt-get install -y clang
+      - name: Compile all solutions
+        run: |
+          set -e
+          for cpp in $(find . -type f \( -name 'a.cpp' -o -name 'b.cpp' \)); do
+            dir=$(dirname "$cpp")
+            base=$(basename "$cpp" .cpp)
+            out_dir="build/${{ matrix.compiler }}/$dir"
+            mkdir -p "$out_dir"
+            ${{ matrix.compiler }} -std=c++23 -O2 "$cpp" -o "$out_dir/$base"
+          done


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that compiles every `a.cpp` and `b.cpp`
  using `gcc` and `clang` with `-std=c++23 -O2`
- workflow can be triggered on pull requests and manually via `workflow_dispatch`
- install latest `g++-13` before building

## Testing
- `pytest -q`
