### PR TITLE
Fix GitHub Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,54 @@
+name: Deploy static content to Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Generate index.html
+        run: |
+          mkdir -p site
+          echo '<!DOCTYPE html><html><head><meta charset="UTF-8"><title>Advent of Code Solutions</title></head><body>' > site/index.html
+          echo '<table border="1">' >> site/index.html
+          echo '<tr><th>Day</th><th>a.cpp lines</th><th>b.cpp lines</th></tr>' >> site/index.html
+          for day in $(seq -w 1 25); do
+            dir="2024/$day"
+            a_lines=""
+            b_lines=""
+            if [ -f "$dir/a.cpp" ]; then
+              a_lines=$(wc -l < "$dir/a.cpp" | xargs)
+            fi
+            if [ -f "$dir/b.cpp" ]; then
+              b_lines=$(wc -l < "$dir/b.cpp" | xargs)
+            fi
+            echo "<tr><td>$day</td><td>${a_lines}</td><td>${b_lines}</td></tr>" >> site/index.html
+          done
+          echo '</table></body></html>' >> site/index.html
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+

--- a/README.md
+++ b/README.md
@@ -5,3 +5,6 @@ This repository contains C++ solutions for the Advent of Code 2024 puzzles.
 [![Build Status](https://github.com/miracoli/Advent-of-Code/actions/workflows/build.yml/badge.svg)](https://github.com/miracoli/Advent-of-Code/actions/workflows/build.yml)
 
 Each day has its own directory under `2024/` containing `a.cpp`, `b.cpp` and a `README.md` describing the approach.
+
+An overview of the line counts for all solutions is published on [GitHub Pages](https://miracoli.github.io/Advent-of-Code/).
+


### PR DESCRIPTION
## Summary
- rework `pages.yml` following the latest GitHub example
- still generate `index.html` with line counts and deploy it with Pages

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_b_683d6a64dde48331a9611252c03ef129