### PR TITLE
Run AoC solutions in CI after git-crypt unlock

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,8 +12,16 @@ jobs:
     strategy:
       matrix:
         compiler: [g++, clang++]
+    env:
+      GITCRYPT_KEY_B64: ${{ secrets.GITCRYPT_KEY_B64 }}
     steps:
       - uses: actions/checkout@v3
+      - name: Install git-crypt
+        run: sudo apt-get update && sudo apt-get install -y git-crypt
+      - name: Unlock encrypted inputs
+        run: |
+          echo "$GITCRYPT_KEY_B64" | base64 --decode > gitcrypt.key
+          git-crypt unlock gitcrypt.key
       - name: Install g++-14
         if: matrix.compiler == 'g++'
         run: |
@@ -32,4 +40,16 @@ jobs:
             out_dir="build/${{ matrix.compiler }}/$dir"
             mkdir -p "$out_dir"
             ${{ matrix.compiler }} -std=c++23 -O2 "$cpp" -o "$out_dir/$base"
+          done
+      - name: Run all solutions
+        run: |
+          set -e
+          for day in $(seq -w 1 25); do
+            dir="2024/$day"
+            if [ -f "$dir/a.cpp" ]; then
+              (cd "$dir" && ../../build/${{ matrix.compiler }}/$dir/a)
+            fi
+            if [ -f "$dir/b.cpp" ]; then
+              (cd "$dir" && ../../build/${{ matrix.compiler }}/$dir/b)
+            fi
           done


### PR DESCRIPTION
## Summary
- decrypt inputs in CI using a base64 secret
- run each day's compiled `a` and `b` solutions using the decrypted inputs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683976e375a0833181b4d5617c751443