### PR TITLE
Show solution path in build run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,9 +47,11 @@ jobs:
           for day in $(seq -w 1 25); do
             dir="2024/$day"
             if [ -f "$dir/a.cpp" ]; then
+              echo "Running $dir/a"
               (cd "$dir" && ../../build/${{ matrix.compiler }}/$dir/a)
             fi
             if [ -f "$dir/b.cpp" ]; then
+              echo "Running $dir/b"
               (cd "$dir" && ../../build/${{ matrix.compiler }}/$dir/b)
             fi
           done


### PR DESCRIPTION
## Summary
- improve build workflow to display which solution is executed

## Testing
- `cargo test` *(fails: could not find `Cargo.toml`)*

------
https://chatgpt.com/codex/tasks/task_b_6842e0551100833192ab4189964121ab