### PR TITLE
Add hyperfine benchmarking and update pages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,11 +80,11 @@ jobs:
             dir="2024/$day"
             if [ -f "$dir/a.cpp" ]; then
               echo "Running $dir/a with hyperfine"
-              (cd "$dir" && hyperfine -N -u microseconds -w 50 -r 50 ../../build/${{ matrix.compiler }}/$dir/a)
+              (cd "$dir" && hyperfine -N -u microsecond -w 50 -r 50 ../../build/${{ matrix.compiler }}/$dir/a)
             fi
             if [ -f "$dir/b.cpp" ]; then
               echo "Running $dir/b with hyperfine"
-              (cd "$dir" && hyperfine -N -u microseconds -w 50 -r 50 ../../build/${{ matrix.compiler }}/$dir/b)
+              (cd "$dir" && hyperfine -N -u microsecond -w 50 -r 50 ../../build/${{ matrix.compiler }}/$dir/b)
             fi
           done
       - name: Run all solutions

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y g++-14
           sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 100
+      - name: Install hyperfine
+        if: matrix.compiler == 'g++'
+        run: sudo apt-get update && sudo apt-get install -y hyperfine
       - name: Install clang
         if: matrix.compiler == 'clang++'
         run: sudo apt-get update && sudo apt-get install -y clang
@@ -69,8 +72,23 @@ jobs:
             mkdir -p "$out_dir"
             ${{ matrix.compiler }} -std=c++23 -O2 "$cpp" -o "$out_dir/$base"
           done
+      - name: Run all solutions with hyperfine
+        if: runner.os != 'Windows' && matrix.compiler == 'g++'
+        run: |
+          set -e
+          for day in $(seq -w 1 25); do
+            dir="2024/$day"
+            if [ -f "$dir/a.cpp" ]; then
+              echo "Running $dir/a with hyperfine"
+              (cd "$dir" && hyperfine -N -u microseconds -w 50 -r 50 ../../build/${{ matrix.compiler }}/$dir/a)
+            fi
+            if [ -f "$dir/b.cpp" ]; then
+              echo "Running $dir/b with hyperfine"
+              (cd "$dir" && hyperfine -N -u microseconds -w 50 -r 50 ../../build/${{ matrix.compiler }}/$dir/b)
+            fi
+          done
       - name: Run all solutions
-        if: runner.os != 'Windows'
+        if: runner.os != 'Windows' && matrix.compiler != 'g++'
         run: |
           set -e
           for day in $(seq -w 1 25); do

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -44,14 +44,14 @@ jobs:
             b_time=""
             if [ -f "$dir/a.cpp" ]; then
               a_lines=$(wc -l < "$dir/a.cpp" | xargs)
-              g++ -std=c++23 -O2 "$dir/a.cpp" -o "$dir/a"
-              hyperfine -N -u microseconds -w 50 -r 50 "./$dir/a" --export-json /tmp/a.json > /dev/null
+              (cd "$dir" && g++ -std=c++23 -O2 a.cpp -o a)
+              (cd "$dir" && hyperfine -N -u microsecond -w 50 -r 50 ./a --export-json /tmp/a.json > /dev/null)
               a_time=$(jq '.results[0].mean' /tmp/a.json)
             fi
             if [ -f "$dir/b.cpp" ]; then
               b_lines=$(wc -l < "$dir/b.cpp" | xargs)
-              g++ -std=c++23 -O2 "$dir/b.cpp" -o "$dir/b"
-              hyperfine -N -u microseconds -w 50 -r 50 "./$dir/b" --export-json /tmp/b.json > /dev/null
+              (cd "$dir" && g++ -std=c++23 -O2 b.cpp -o b)
+              (cd "$dir" && hyperfine -N -u microsecond -w 50 -r 50 ./b --export-json /tmp/b.json > /dev/null)
               b_time=$(jq '.results[0].mean' /tmp/b.json)
             fi
             echo "<tr><td>$day</td><td>${a_lines}</td><td>${b_lines}</td><td>${a_time}</td><td>${b_time}</td></tr>" >> site/index.html

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -25,23 +25,36 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v5
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y g++-14 hyperfine jq
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 100
       - name: Generate index.html
         run: |
           mkdir -p site
           echo '<!DOCTYPE html><html><head><meta charset="UTF-8"><title>Advent of Code Solutions</title></head><body>' > site/index.html
           echo '<table border="1">' >> site/index.html
-          echo '<tr><th>Day</th><th>a.cpp lines</th><th>b.cpp lines</th></tr>' >> site/index.html
+          echo '<tr><th>Day</th><th>a.cpp lines</th><th>b.cpp lines</th><th>a time (µs)</th><th>b time (µs)</th></tr>' >> site/index.html
           for day in $(seq -w 1 25); do
             dir="2024/$day"
             a_lines=""
             b_lines=""
+            a_time=""
+            b_time=""
             if [ -f "$dir/a.cpp" ]; then
               a_lines=$(wc -l < "$dir/a.cpp" | xargs)
+              g++ -std=c++23 -O2 "$dir/a.cpp" -o "$dir/a"
+              hyperfine -N -u microseconds -w 50 -r 50 "./$dir/a" --export-json /tmp/a.json > /dev/null
+              a_time=$(jq '.results[0].mean' /tmp/a.json)
             fi
             if [ -f "$dir/b.cpp" ]; then
               b_lines=$(wc -l < "$dir/b.cpp" | xargs)
+              g++ -std=c++23 -O2 "$dir/b.cpp" -o "$dir/b"
+              hyperfine -N -u microseconds -w 50 -r 50 "./$dir/b" --export-json /tmp/b.json > /dev/null
+              b_time=$(jq '.results[0].mean' /tmp/b.json)
             fi
-            echo "<tr><td>$day</td><td>${a_lines}</td><td>${b_lines}</td></tr>" >> site/index.html
+            echo "<tr><td>$day</td><td>${a_lines}</td><td>${b_lines}</td><td>${a_time}</td><td>${b_time}</td></tr>" >> site/index.html
           done
           echo '</table></body></html>' >> site/index.html
       - name: Upload artifact


### PR DESCRIPTION
## Summary
- benchmark GCC builds with hyperfine
- install hyperfine on the Pages workflow
- compile & time each program and show runtime columns on the GitHub Pages table

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_6842f6ba210c833189af479569a79330