### PR TITLE
Add hyperfine benchmark only on pages build

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -25,23 +25,36 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v5
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y g++-14 hyperfine jq
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 100
       - name: Generate index.html
         run: |
           mkdir -p site
           echo '<!DOCTYPE html><html><head><meta charset="UTF-8"><title>Advent of Code Solutions</title></head><body>' > site/index.html
           echo '<table border="1">' >> site/index.html
-          echo '<tr><th>Day</th><th>a.cpp lines</th><th>b.cpp lines</th></tr>' >> site/index.html
+          echo '<tr><th>Day</th><th>a.cpp lines</th><th>b.cpp lines</th><th>a time (µs)</th><th>b time (µs)</th></tr>' >> site/index.html
           for day in $(seq -w 1 25); do
             dir="2024/$day"
             a_lines=""
             b_lines=""
+            a_time=""
+            b_time=""
             if [ -f "$dir/a.cpp" ]; then
               a_lines=$(wc -l < "$dir/a.cpp" | xargs)
+              (cd "$dir" && g++ -std=c++23 -O2 a.cpp -o a)
+              (cd "$dir" && hyperfine -N -u microsecond -w 50 -r 50 ./a --export-json /tmp/a.json > /dev/null)
+              a_time=$(jq '.results[0].mean' /tmp/a.json)
             fi
             if [ -f "$dir/b.cpp" ]; then
               b_lines=$(wc -l < "$dir/b.cpp" | xargs)
+              (cd "$dir" && g++ -std=c++23 -O2 b.cpp -o b)
+              (cd "$dir" && hyperfine -N -u microsecond -w 50 -r 50 ./b --export-json /tmp/b.json > /dev/null)
+              b_time=$(jq '.results[0].mean' /tmp/b.json)
             fi
-            echo "<tr><td>$day</td><td>${a_lines}</td><td>${b_lines}</td></tr>" >> site/index.html
+            echo "<tr><td>$day</td><td>${a_lines}</td><td>${b_lines}</td><td>${a_time}</td><td>${b_time}</td></tr>" >> site/index.html
           done
           echo '</table></body></html>' >> site/index.html
       - name: Upload artifact


### PR DESCRIPTION
## Summary
- benchmark GCC builds with hyperfine in the Pages workflow
- show timing results in the generated HTML table
- remove hyperfine step from the regular build workflow

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_6842f6ba210c833189af479569a79330