### PR TITLE
Update workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,23 +72,8 @@ jobs:
             mkdir -p "$out_dir"
             ${{ matrix.compiler }} -std=c++23 -O2 "$cpp" -o "$out_dir/$base"
           done
-      - name: Run all solutions with hyperfine
-        if: runner.os != 'Windows' && matrix.compiler == 'g++'
-        run: |
-          set -e
-          for day in $(seq -w 1 25); do
-            dir="2024/$day"
-            if [ -f "$dir/a.cpp" ]; then
-              echo "Running $dir/a with hyperfine"
-              (cd "$dir" && hyperfine -N -u microsecond -w 50 -r 50 ../../build/${{ matrix.compiler }}/$dir/a)
-            fi
-            if [ -f "$dir/b.cpp" ]; then
-              echo "Running $dir/b with hyperfine"
-              (cd "$dir" && hyperfine -N -u microsecond -w 50 -r 50 ../../build/${{ matrix.compiler }}/$dir/b)
-            fi
-          done
       - name: Run all solutions
-        if: runner.os != 'Windows' && matrix.compiler != 'g++'
+        if: runner.os != 'Windows'
         run: |
           set -e
           for day in $(seq -w 1 25); do

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -54,13 +54,13 @@ jobs:
               a_lines=$(wc -l < "$dir/a.cpp" | xargs)
               (cd "$dir" && g++ -std=c++23 -O2 a.cpp -o a)
               (cd "$dir" && hyperfine -N -u microsecond -w 50 -r 50 ./a --export-json /tmp/a.json > /dev/null)
-              a_time=$(jq '.results[0].mean' /tmp/a.json)
+              a_time=$(jq '.results[0].mean * 1000' /tmp/a.json)
             fi
             if [ -f "$dir/b.cpp" ]; then
               b_lines=$(wc -l < "$dir/b.cpp" | xargs)
               (cd "$dir" && g++ -std=c++23 -O2 b.cpp -o b)
               (cd "$dir" && hyperfine -N -u microsecond -w 50 -r 50 ./b --export-json /tmp/b.json > /dev/null)
-              b_time=$(jq '.results[0].mean' /tmp/b.json)
+              b_time=$(jq '.results[0].mean * 1000' /tmp/b.json)
             fi
             echo "<tr><td>$day</td><td>${a_lines}</td><td>${b_lines}</td><td>${a_time}</td><td>${b_time}</td></tr>" >> site/index.html
           done


### PR DESCRIPTION
## Summary
- remove hyperfine benchmarking step from build.yml
- run compiled solutions directly on Linux
- convert timing data to µs in pages workflow

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_6843e7fdacbc8331b85da2242a6d0650