### PR TITLE
Add totals to pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -44,6 +44,8 @@ jobs:
           echo '<!DOCTYPE html><html><head><meta charset="UTF-8"><title>Advent of Code Solutions</title></head><body>' > site/index.html
           echo '<table border="1">' >> site/index.html
           echo '<tr><th>Day</th><th>a.cpp lines</th><th>b.cpp lines</th><th>a time (µs)</th><th>b time (µs)</th></tr>' >> site/index.html
+          a_sum=0
+          b_sum=0
           for day in $(seq -w 1 25); do
             dir="2024/$day"
             a_lines=""
@@ -54,16 +56,26 @@ jobs:
               a_lines=$(wc -l < "$dir/a.cpp" | xargs)
               (cd "$dir" && g++ -std=c++23 -O2 a.cpp -o a)
               (cd "$dir" && hyperfine -N -u microsecond -w 50 -r 50 ./a --export-json /tmp/a.json > /dev/null)
-              a_time=$(jq '.results[0].mean * 1000' /tmp/a.json)
+              a_time_raw=$(jq '.results[0].mean * 1000' /tmp/a.json)
+              a_time=$(printf "%.2f" "$a_time_raw")
+              a_sum=$(awk "BEGIN {print $a_sum + $a_time}")
             fi
             if [ -f "$dir/b.cpp" ]; then
               b_lines=$(wc -l < "$dir/b.cpp" | xargs)
               (cd "$dir" && g++ -std=c++23 -O2 b.cpp -o b)
               (cd "$dir" && hyperfine -N -u microsecond -w 50 -r 50 ./b --export-json /tmp/b.json > /dev/null)
-              b_time=$(jq '.results[0].mean * 1000' /tmp/b.json)
+              b_time_raw=$(jq '.results[0].mean * 1000' /tmp/b.json)
+              b_time=$(printf "%.2f" "$b_time_raw")
+              b_sum=$(awk "BEGIN {print $b_sum + $b_time}")
             fi
             echo "<tr><td>$day</td><td>${a_lines}</td><td>${b_lines}</td><td>${a_time}</td><td>${b_time}</td></tr>" >> site/index.html
           done
+          a_sum=$(printf "%.2f" "$a_sum")
+          b_sum=$(printf "%.2f" "$b_sum")
+          overall_sum=$(awk "BEGIN {print $a_sum + $b_sum}")
+          overall_sum=$(printf "%.2f" "$overall_sum")
+          echo "<tr><td>Sum</td><td></td><td></td><td>${a_sum}</td><td>${b_sum}</td></tr>" >> site/index.html
+          echo "<tr><td>Overall</td><td></td><td></td><td colspan=\"2\">${overall_sum}</td></tr>" >> site/index.html
           echo '</table></body></html>' >> site/index.html
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary
- format hyperfine results to two decimals
- add running totals and overall total to generated index

## Testing
- `tail -n 20 .github/workflows/pages.yml`

------
https://chatgpt.com/codex/tasks/task_b_6843ebcc83f48331822267ececa34717