### PR TITLE
Add solution check step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,3 +87,8 @@ jobs:
               (cd "$dir" && ../../build/${{ matrix.compiler }}/$dir/b)
             fi
           done
+      - name: Test outputs
+        if: runner.os != 'Windows'
+        env:
+          COMPILER: ${{ matrix.compiler }}
+        run: ./tests/run_solutions.sh

--- a/tests/run_solutions.sh
+++ b/tests/run_solutions.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+compiler="${COMPILER:-g++}"
+
+for day in $(seq -w 1 25); do
+    dir="2024/$day"
+    solution="$dir/solution.txt"
+    if [ -f "$dir/a.cpp" ] || [ -f "$dir/b.cpp" ]; then
+        if [ ! -f "$solution" ]; then
+            echo "Missing solution file for $dir" >&2
+            exit 1
+        fi
+    else
+        continue
+    fi
+
+    if [ -f "$dir/a.cpp" ]; then
+        expected=$(sed -n '1p' "$solution")
+        output=$(cd "$dir" && ../../build/"$compiler"/"$dir"/a)
+        if [ "$output" != "$expected" ]; then
+            echo "Day $day part A failed: expected '$expected', got '$output'" >&2
+            exit 1
+        fi
+    fi
+
+    if [ -f "$dir/b.cpp" ]; then
+        expected=$(sed -n '2p' "$solution")
+        output=$(cd "$dir" && ../../build/"$compiler"/"$dir"/b)
+        if [ "$output" != "$expected" ]; then
+            echo "Day $day part B failed: expected '$expected', got '$output'" >&2
+            exit 1
+        fi
+    fi
+
+done
+
+echo "All solution tests passed."


### PR DESCRIPTION
## Summary
- add bash script to check outputs of solutions
- update build workflow to run script after executing solutions
- fail tests when a solution file is missing

## Testing
- `g++ -std=c++23 -O2 2024/01/a.cpp -o build/g++/2024/01/a`
- `g++ -std=c++23 -O2 2024/01/b.cpp -o build/g++/2024/01/b`
- `COMPILER=g++ ./tests/run_solutions.sh` *(fails: Missing solution file for 2024/02)*


------
https://chatgpt.com/codex/tasks/task_b_684597c69900833199c2ac0671d18696