### PR TITLE
Add SonarCloud integration

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,69 @@
+name: SonarCloud Analysis
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    name: SonarCloud
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install g++-14
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y g++-14
+
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
+      - name: Cache SonarCloud build-wrapper
+        id: build-wrapper-cache
+        uses: actions/cache@v3
+        with:
+          path: build-wrapper-linux-x86
+          key: ${{ runner.os }}-build-wrapper
+          restore-keys: ${{ runner.os }}-build-wrapper
+
+      - name: Download build-wrapper
+        if: steps.build-wrapper-cache.outputs.cache-hit != 'true'
+        run: |
+          curl -sSLo build-wrapper-linux-x86.zip https://sonarcloud.io/static/cpp/build-wrapper-linux-x86.zip
+          unzip -q build-wrapper-linux-x86.zip
+
+      - name: Build with build-wrapper
+        run: |
+          mkdir -p build
+          ./build-wrapper-linux-x86/build-wrapper-linux-x86-64 --out-dir bw-output bash -c '
+            set -e
+            for cpp in $(find 2024 -type f \( -name "a.cpp" -o -name "b.cpp" \)); do
+              dir=$(dirname "$cpp")
+              base=$(basename "$cpp" .cpp)
+              out_dir="build/$dir"
+              mkdir -p "$out_dir"
+              g++-14 -std=c++23 -O2 "$cpp" -o "$out_dir/$base"
+            done
+          '
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+      - name: SonarCloud Quality Gate
+        uses: SonarSource/sonarqube-quality-gate-action@master
+        timeout-minutes: 5
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: https://sonarcloud.io

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+build/
+bw-output/
+build-wrapper-linux-x86/
+build-wrapper-linux-x86.zip

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This repository contains C++ solutions for the Advent of Code 2024 puzzles.
 
 [![Build Status](https://github.com/miracoli/Advent-of-Code/actions/workflows/build.yml/badge.svg)](https://github.com/miracoli/Advent-of-Code/actions/workflows/build.yml)
 
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=miracoli_Advent-of-Code&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=miracoli_Advent-of-Code)
+
 Each day has its own directory under `2024/` containing `a.cpp`, `b.cpp` and a `README.md` describing the approach.
 
 An overview of the line counts for all solutions is published on [GitHub Pages](https://miracoli.github.io/Advent-of-Code/).

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,10 @@
+sonar.projectKey=miracoli_Advent-of-Code
+sonar.organization=miracoli
+sonar.projectName=Advent-of-Code
+sonar.host.url=https://sonarcloud.io
+
+sonar.sources=2024
+sonar.inclusions=**/*.cpp
+sonar.sourceEncoding=UTF-8
+
+sonar.cfamily.build-wrapper-output=bw-output


### PR DESCRIPTION
## Summary
- add a dedicated SonarCloud GitHub Actions workflow that builds the C++ solutions with the build-wrapper and runs the quality gate check
- configure the SonarCloud project properties for the repository and ignore analysis artefacts
- document the new quality gate status badge in the README

## Testing
- not run (g++-14 is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_b_68ca6a0ceef883319864df753cf8a759