### PR TITLE
Use contains() for membership checks

### DIFF
--- a/2024/05/a.cpp
+++ b/2024/05/a.cpp
@@ -17,7 +17,7 @@ int main() {
 
   unordered_map<int, unordered_set<int>> rules;
 
-  for (string line; getline(inputFile, line) && line.find('|') != string::npos;) {
+  for (string line; getline(inputFile, line) && line.contains('|');) {
     int from, to; 
     char delim; 
     stringstream(line) >> from >> delim >> to;
@@ -32,7 +32,7 @@ int main() {
 
     middleSum += [&rules, &ss, &seq, &pos]() {
       for (int n; ss >> n; ss.ignore(1, ',')) {
-        if (!all_of(rules[n].begin(), rules[n].end(), [&pos](int to) { return !pos.count(to); })) {
+        if (!all_of(rules[n].begin(), rules[n].end(), [&pos](int to) { return !pos.contains(to); })) {
           return 0;
         }
         seq.push_back(n);

--- a/2024/05/b.cpp
+++ b/2024/05/b.cpp
@@ -16,7 +16,7 @@ int main() {
 
   unordered_map<int, unordered_set<int>> rules;
 
-  for (string line; getline(inputFile, line) && line.find('|') != string::npos;) {
+  for (string line; getline(inputFile, line) && line.contains('|');) {
     int from, to; 
     char delim; 
     stringstream(line) >> from >> delim >> to;
@@ -31,14 +31,14 @@ int main() {
     bool isInvalid = false;
 
     for (int n; ss >> n; ss.ignore(1, ',')) {
-      if (!isInvalid && !all_of(rules[n].begin(), rules[n].end(), [&pos](int to) { return !pos.count(to); })) {
+      if (!isInvalid && !all_of(rules[n].begin(), rules[n].end(), [&pos](int to) { return !pos.contains(to); })) {
         isInvalid = true;
       }
       seq.push_back(n);
       pos.insert(n);
     }
     if(isInvalid) {
-      stable_sort(seq.begin(), seq.end(), [&rules](int a, int b) { return rules[a].count(b); });
+      stable_sort(seq.begin(), seq.end(), [&rules](int a, int b) { return rules[a].contains(b); });
       middleSum += seq[seq.size() / 2];
     }
   };

--- a/2024/18/b.cpp
+++ b/2024/18/b.cpp
@@ -72,7 +72,7 @@ int main() {
       continue;
     }
 
-    if (pathCells.count(x * N + y)) {
+    if (pathCells.contains(x * N + y)) {
       solvable = bfs();
     }
   }

--- a/2024/23/a.cpp
+++ b/2024/23/a.cpp
@@ -22,7 +22,7 @@ int main() {
   for (const auto& [node, neighbors] : connections) {
     for (const auto& neighbor : neighbors) {
       for (const auto& common : connections[neighbor]) {
-        if (connections[node].count(common) && (node[0] == 't' || neighbor[0] == 't' || common[0] == 't')) {
+        if (connections[node].contains(common) && (node[0] == 't' || neighbor[0] == 't' || common[0] == 't')) {
           ++count;
         }
       }

--- a/2024/23/b.cpp
+++ b/2024/23/b.cpp
@@ -26,12 +26,12 @@ void findLargestClique(unordered_set<int>& R, unordered_set<int>& P, unordered_s
     R_new.insert(v);
 
     for (int p : P) {
-      if (connections[v].count(p)) {
+      if (connections[v].contains(p)) {
         P_new.insert(p);
       }
     }
     for (int x : X) {
-      if (connections[v].count(x)) {
+      if (connections[v].contains(x)) {
         X_new.insert(x);
       }
     }

--- a/2024/24/a.cpp
+++ b/2024/24/a.cpp
@@ -25,7 +25,7 @@ int main() {
     auto [input1, input2, op, output] = pendingGates.front();
     pendingGates.pop();
 
-    if (wireValues.count(input1) && wireValues.count(input2)) {
+    if (wireValues.contains(input1) && wireValues.contains(input2)) {
       bool v1 = wireValues[input1], v2 = wireValues[input2];
       wireValues[output] = (op == "AND" ? v1 & v2 : op == "OR" ? v1 | v2 :  v1 ^ v2);
     } else {


### PR DESCRIPTION
## Summary
- replace container `count()` usage with `contains()` throughout the affected solutions
- swap simple `find()` checks that only test presence for `contains()`

## Testing
- `for cpp in $(find . -type f \( -name 'a.cpp' -o -name 'b.cpp' \)); do dir=$(dirname "$cpp"); base=$(basename "$cpp" .cpp); out_dir="build/g++/$dir"; mkdir -p "$out_dir"; g++ -std=c++23 -Werror -O2 "$cpp" -o "$out_dir/$base"; done`
- `./tests/run_solutions.sh` *(fails: encrypted solution outputs unavailable without git-crypt key)*

------
https://chatgpt.com/codex/tasks/task_b_68cb9dc2c13883319c5cdccb25672aeb