### PR TITLE
Remove unused variables and stray semicolon

### DIFF
--- a/2024/05/b.cpp
+++ b/2024/05/b.cpp
@@ -41,7 +41,7 @@ int main() {
       stable_sort(seq.begin(), seq.end(), [&rules](int a, int b) { return rules[a].count(b); });
       middleSum += seq[seq.size() / 2];
     }
-  };
+  }
 
   cout << middleSum << endl;
 }

--- a/2024/07/a.cpp
+++ b/2024/07/a.cpp
@@ -24,7 +24,7 @@ int main() {
 
   for (string line; getline(in, line); ) {
     stringstream ss(line);
-    uint64_t target, num;
+    uint64_t target;
     char colon;
     ss >> target >> colon;
     vector<uint64_t> nums{istream_iterator<uint64_t>{ss}, {}};

--- a/2024/07/b.cpp
+++ b/2024/07/b.cpp
@@ -26,7 +26,7 @@ int main() {
 
     for (string line; getline(in, line); ) {
         stringstream ss(line);
-        uint64_t target, num;
+        uint64_t target;
         char colon;
         ss >> target >> colon;
         vector<uint64_t> nums{istream_iterator<uint64_t>{ss}, {}};


### PR DESCRIPTION
## Summary
- drop unused accumulator variables from Day 7 solutions
- remove a stray semicolon that left an empty statement in Day 5 part B

## Testing
- g++ -std=c++20 -Wall -Wextra -Werror 2024/05/b.cpp -o /tmp/day05b
- g++ -std=c++20 -Wall -Wextra -Werror 2024/07/a.cpp -o /tmp/day07a
- g++ -std=c++20 -Wall -Wextra -Werror 2024/07/b.cpp -o /tmp/day07b

------
https://chatgpt.com/codex/tasks/task_b_68cba093608c833187d5a5ba3510c79b