### PR TITLE
Switch day 23 part B ID map to try_emplace

### DIFF
--- a/2024/23/b.cpp
+++ b/2024/23/b.cpp
@@ -50,7 +50,7 @@ int main() {
   vector<string> name;
 
   auto getId = [&id, &name](const string& s) -> int {
-    auto [it, added] = id.emplace(s, (int)id.size());
+    auto [it, added] = id.try_emplace(s, (int)id.size());
     if (added) name.push_back(s);
     return it->second;
   };


### PR DESCRIPTION
## Summary
- replace the unordered_map::emplace call in day 23 part B with try_emplace to avoid unnecessary moves when a key already exists

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68ccfaaacc108331abb35f91c8b963d3