### PR TITLE
Fix indentation in Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -42,8 +42,8 @@ jobs:
         run: |
           mkdir -p site
           cat <<'EOF' > site/index.html
-<!DOCTYPE html><html><head><meta charset="UTF-8"><title>Advent of Code Solutions</title></head><body>
-EOF
+          <!DOCTYPE html><html><head><meta charset="UTF-8"><title>Advent of Code Solutions</title></head><body>
+          EOF
           mapfile -t years < <(find . -mindepth 1 -maxdepth 1 -type d -regex './[0-9]\{4\}' -printf '%f\n' | sort)
           if [ ${#years[@]} -eq 0 ]; then
             echo '<p>No solution data available.</p>' >> site/index.html


### PR DESCRIPTION
## Summary
- fix indentation of heredoc content in Pages deployment script to satisfy YAML parser

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d0e1323df88331b2f2ff56f371bc83