### PR TITLE
Fix year directory detection in Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -44,7 +44,7 @@ jobs:
           cat <<'EOF' > site/index.html
           <!DOCTYPE html><html><head><meta charset="UTF-8"><title>Advent of Code Solutions</title></head><body>
           EOF
-          mapfile -t years < <(find . -mindepth 1 -maxdepth 1 -type d -regex './[0-9]\{4\}' -printf '%f\n' | sort)
+          mapfile -t years < <(find . -mindepth 1 -maxdepth 1 -type d -name '[0-9][0-9][0-9][0-9]' -printf '%f\n' | sort)
           if [ ${#years[@]} -eq 0 ]; then
             echo '<p>No solution data available.</p>' >> site/index.html
           fi


### PR DESCRIPTION
## Summary
- update the Pages workflow to gather year directories by name pattern
- prevent the generated index from showing "No solution data available" when year folders exist

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d0ec25ed088331bf46d8accb5b2ce8