### PR TITLE
Include 2023 directory in SonarCloud build

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -77,7 +77,7 @@ jobs:
               out_dir="build/$dir"
               mkdir -p "$out_dir"
               "$cxx" -std=c++23 -O2 "$cpp" -o "$out_dir/$base"
-            done < <(find 2024 -type f \( -name "a.cpp" -o -name "b.cpp" \))
+            done < <(find 2023 2024 -type f \( -name "a.cpp" -o -name "b.cpp" \))
           '
 
       - name: SonarCloud Scan


### PR DESCRIPTION
## Summary
- extend the SonarCloud workflow to compile both the 2023 and 2024 solution directories

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_b_68d0fa36e8f08331aa09fc0d1fa6bd86