### PR TITLE
Remove utility includes from move qualification change

### DIFF
--- a/2024/06/b.cpp
+++ b/2024/06/b.cpp
@@ -15,7 +15,7 @@ int main() {
   vector<string> map;
   int startX = 0, startY = 0;
 
-  for (string line; getline(inputFile, line); map.emplace_back(move(line))) {
+  for (string line; getline(inputFile, line); map.emplace_back(std::move(line))) {
     if (auto pos = line.find('^'); pos != string::npos) {
       startX = (int)pos; startY = (int)map.size();
     }

--- a/2024/11/a.cpp
+++ b/2024/11/a.cpp
@@ -37,7 +37,7 @@ int main() {
       }
     }
 
-    stones = move(next);
+    stones = std::move(next);
   }
 
   cout << accumulate(stones.begin(), stones.end(), 0LL, [](long long sum, const auto& p) { return sum + p.second; }) << endl;

--- a/2024/15/a.cpp
+++ b/2024/15/a.cpp
@@ -27,7 +27,7 @@ int main() {
     cerr << "Error: input.txt not found" << endl;
     return 1;
   }
-  for (string line; getline(input, line) && !line.empty(); grid.emplace_back(move(line))) {
+  for (string line; getline(input, line) && !line.empty(); grid.emplace_back(std::move(line))) {
     for (int x = 0; x < line.size(); ++x) {
       if (line[x] == '@') {
         robot = {x, static_cast<int>(grid.size())};

--- a/2024/15/b.cpp
+++ b/2024/15/b.cpp
@@ -13,12 +13,12 @@ pair<int, int> robot;
 int gpsSum = 0;
 
 bool moveBox(const pair<int, int>& box, const pair<int, int>& delta, bool simulate = false) {
-    auto move = [&delta, &simulate, &box](const pair<int, int>& p) {
+    auto attemptMove = [&delta, &simulate, &box](const pair<int, int>& p) {
         if (grid[p.second][p.first] == '.' || (grid[p.second][p.first] == '[' || grid[p.second][p.first] == ']') && moveBox(p, delta, simulate)) {
             if (!simulate) {
                 swap(grid[p.second][p.first], grid[box.second][delta.second ? p.first : box.first]);
                 if(grid[p.second][p.first] == '[') {
-                  gpsSum += 100 * delta.second + delta.first; 
+                  gpsSum += 100 * delta.second + delta.first;
                 }
             }
             return true;
@@ -29,9 +29,9 @@ bool moveBox(const pair<int, int>& box, const pair<int, int>& delta, bool simula
     if (delta.second) { // vertical move
        pair<int, int> newBoxR = {box.first + delta.first + (grid[box.second][box.first] == '['), box.second + delta.second};
        pair<int, int> newBoxL = {box.first + delta.first - (grid[box.second][box.first] != '['), box.second + delta.second};
-       return move(newBoxL) && move(newBoxR);
-    } 
-    return move({box.first + delta.first, box.second + delta.second}); // horizontal move
+       return attemptMove(newBoxL) && attemptMove(newBoxR);
+    }
+    return attemptMove({box.first + delta.first, box.second + delta.second}); // horizontal move
 }
 
 int main() {
@@ -41,7 +41,7 @@ int main() {
     return 1;
   }
 
-  for (string line; getline(input, line) && !line.empty(); grid.emplace_back(move(line))) {
+  for (string line; getline(input, line) && !line.empty(); grid.emplace_back(std::move(line))) {
     for (size_t x = 0; x < line.size(); x += 2) {
       line.replace(x, 1, (line[x] == 'O') ? (gpsSum += 100 * grid.size() + x, "[]") : (line[x] == '@') ? (robot = {x, (int)grid.size()}, "@.") : string(2, line[x]));
     }

--- a/2024/16/a.cpp
+++ b/2024/16/a.cpp
@@ -21,7 +21,7 @@ int main() {
   vector<string> grid;
   pair<uint_fast16_t, uint_fast16_t> start;
 
-  for (string line; getline(input, line); grid.emplace_back(move(line))) {
+  for (string line; getline(input, line); grid.emplace_back(std::move(line))) {
     if (auto pos = line.find('S'); pos != string::npos) {
       start = {pos, grid.size()};
     }

--- a/2024/16/b.cpp
+++ b/2024/16/b.cpp
@@ -22,7 +22,7 @@ int main() {
   vector<string> grid;
   pair<uint_fast16_t, uint_fast16_t> start, end;
 
-  for (string line; getline(input, line); grid.emplace_back(move(line))) {
+  for (string line; getline(input, line); grid.emplace_back(std::move(line))) {
     for (uint_fast8_t col = 0; col < line.size(); ++col) {
       if (line[col] == 'S') {
         start = {grid.size(), col};

--- a/2024/19/a.cpp
+++ b/2024/19/a.cpp
@@ -35,12 +35,12 @@ int main() {
   getline(input, line);
   stringstream ss(line);
   for (string token; getline(ss, token, ',') >> ws; ) {
-    patterns.emplace_back(move(token));
+    patterns.emplace_back(std::move(token));
   }
 
   while (getline(input, line)) {
     if (!line.empty()) {
-      designs.emplace_back(move(line));
+      designs.emplace_back(std::move(line));
     }
   }
   

--- a/2024/19/b.cpp
+++ b/2024/19/b.cpp
@@ -38,12 +38,12 @@ int main() {
   getline(input, line);
   stringstream ss(line);
   for (string token; getline(ss, token, ',') >> ws; ) {
-    patterns.emplace_back(move(token));
+    patterns.emplace_back(std::move(token));
   }
 
   while (getline(input, line)) {
     if (!line.empty()) {
-      designs.emplace_back(move(line));
+      designs.emplace_back(std::move(line));
     }
   }
 

--- a/2024/20/a.cpp
+++ b/2024/20/a.cpp
@@ -20,7 +20,7 @@ int main() {
   vector<string> grid;
   pair<int, int> pos;
     
-  for (string line; getline(input, line); grid.emplace_back(move(line))) {
+  for (string line; getline(input, line); grid.emplace_back(std::move(line))) {
     for (int col = 0; col < line.size(); ++col) {
       if (line[col] == 'S') {
         pos = {grid.size() , col};

--- a/2024/20/b.cpp
+++ b/2024/20/b.cpp
@@ -20,7 +20,7 @@ int main() {
   vector<string> grid;
   pair<int, int> pos;
     
-  for (string line; getline(input, line); grid.emplace_back(move(line))) {
+  for (string line; getline(input, line); grid.emplace_back(std::move(line))) {
     for (int col = 0; col < line.size(); ++col) {
       if (line[col] == 'S') {
         pos = {grid.size() , col};

--- a/2024/21/a.cpp
+++ b/2024/21/a.cpp
@@ -56,7 +56,7 @@ int main() {
     return 1;
   }
   vector<pair<string, int>> input;
-  for (string line; getline(fin, line); input.emplace_back(move(line), stoi(line)));
+  for (string line; getline(fin, line); input.emplace_back(std::move(line), stoi(line)));
 
   cout << transform_reduce(input.begin(), input.end(), 0ULL, plus<>(), [](const auto& p) { return solve(p.first) * p.second; }) << endl;
 }

--- a/2024/21/b.cpp
+++ b/2024/21/b.cpp
@@ -56,7 +56,7 @@ int main() {
     return 1;
   }
   vector<pair<string, int>> input;
-  for (string line; getline(fin, line); input.emplace_back(move(line), stoi(line)));
+  for (string line; getline(fin, line); input.emplace_back(std::move(line), stoi(line)));
 
   cout << transform_reduce(input.begin(), input.end(), 0ULL, plus<>(), [](const auto& p) { return solve(p.first) * p.second; }) << endl;
 }


### PR DESCRIPTION
## Summary
- remove the `<utility>` includes added in the prior change while keeping the `std::move` qualifications intact

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d12fbc6e3c8331a77ec6c89fe00149