### PR TITLE
Use ranges::to for clique output

### DIFF
--- a/2024/23/b.cpp
+++ b/2024/23/b.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <fstream>
 #include <iostream>
+#include <ranges>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -85,8 +86,5 @@ int main() {
   }
   sort(result.begin(), result.end());
 
-  for (size_t i = 0; i < result.size(); ++i) {
-    cout << result[i] << (i + 1 < result.size() ? "," : "");
-  }
-  cout << endl;
+  std::cout << std::ranges::to<std::string>(result | std::views::join_with(',')) << std::endl;
 }


### PR DESCRIPTION
## Summary
- replace the lambda join helper with a direct `std::ranges::to<std::string>` conversion for the clique output

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d13ecddc0883318bfedd4b34189503