### PR TITLE
Update range algorithms for days 18, 21, and 23

### DIFF
--- a/2024/18/a.cpp
+++ b/2024/18/a.cpp
@@ -4,6 +4,7 @@
 #include <fstream>
 #include <algorithm>
 #include <array>
+#include <ranges>
 
 using namespace std;
 
@@ -24,7 +25,7 @@ int main() {
     array<array<bool, 71>, 71> grid{};
 
     for (string line; getline(inputFile, line) && maxCount < 1024; ++maxCount) {
-        replace(line.begin(), line.end(), ',', ' ');
+        ranges::replace(line, ',', ' ');
         if (stringstream(line) >> xCoord >> yCoord) {
             grid[xCoord][yCoord] = true;
         }

--- a/2024/18/b.cpp
+++ b/2024/18/b.cpp
@@ -4,6 +4,7 @@
 #include <sstream>
 #include <algorithm>
 #include <array>
+#include <ranges>
 
 using namespace std;
 
@@ -71,7 +72,7 @@ int main() {
   bool solvable = true;
 
   for (string line; getline(input, line) && solvable;) {
-    replace(line.begin(), line.end(), ',', ' ');
+    ranges::replace(line, ',', ' ');
     (stringstream(line) >> x >> y);
 
     blocked[x][y] = true;

--- a/2024/21/a.cpp
+++ b/2024/21/a.cpp
@@ -7,6 +7,7 @@
 #include <array>
 #include <string>
 #include <cstdint>
+#include <ranges>
 
 using namespace std;
 
@@ -26,22 +27,23 @@ uint64_t solve(string path, char depth = 0) {
     return result;
   }
 
-  auto curr = positions[depth ? 'a' : 'A'], avoid = depth ? array<int8_t, 2>{0, 0} : array<int8_t, 2>{3, 0};
+  auto curr = positions[depth ? 'a' : 'A'];
+  auto avoid = depth ? array<int8_t, 2>{0, 0} : array<int8_t, 2>{3, 0};
   result = 0;
 
   for (char c : path) {
     auto next = positions[c];
         
     string movePath = string(abs(next[0] - curr[0]), (next[0] < curr[0] ? '^' : 'v')) + string(abs(next[1] - curr[1]), (next[1] < curr[1] ? '<' : '>'));
-    sort(movePath.begin(), movePath.end());
+    ranges::sort(movePath);
 
     uint64_t minLen = UINT64_MAX;
     do {
       auto temp = curr;
-      if (all_of(movePath.begin(), movePath.end(), [&temp, &avoid](char step) { temp[0] += directions[step][0], temp[1] += directions[step][1]; return temp != avoid; })) {
+      if (ranges::all_of(movePath, [&temp, &avoid](char step) { temp[0] += directions[step][0], temp[1] += directions[step][1]; return temp != avoid; })) {
         minLen = min(minLen, (depth == limit ? movePath.size() + 1 : solve(movePath + 'a', depth + 1)));
       }
-    } while (next_permutation(movePath.begin(), movePath.end()));
+    } while (ranges::next_permutation(movePath).found);
 
     result += minLen;
     curr = next;

--- a/2024/21/b.cpp
+++ b/2024/21/b.cpp
@@ -7,6 +7,7 @@
 #include <array>
 #include <string>
 #include <cstdint>
+#include <ranges>
 
 using namespace std;
 
@@ -26,22 +27,23 @@ uint64_t solve(string path, char depth = 0) {
     return result;
   }
 
-  auto curr = positions[depth ? 'a' : 'A'], avoid = depth ? array<int8_t, 2>{0, 0} : array<int8_t, 2>{3, 0};
+  auto curr = positions[depth ? 'a' : 'A'];
+  auto avoid = depth ? array<int8_t, 2>{0, 0} : array<int8_t, 2>{3, 0};
   result = 0;
 
   for (char c : path) {
     auto next = positions[c];
         
     string movePath = string(abs(next[0] - curr[0]), (next[0] < curr[0] ? '^' : 'v')) + string(abs(next[1] - curr[1]), (next[1] < curr[1] ? '<' : '>'));
-    sort(movePath.begin(), movePath.end());
+    ranges::sort(movePath);
 
     uint64_t minLen = UINT64_MAX;
     do {
       auto temp = curr;
-      if (all_of(movePath.begin(), movePath.end(), [&temp, &avoid](char step) { temp[0] += directions[step][0], temp[1] += directions[step][1]; return temp != avoid; })) {
+      if (ranges::all_of(movePath, [&temp, &avoid](char step) { temp[0] += directions[step][0], temp[1] += directions[step][1]; return temp != avoid; })) {
         minLen = min(minLen, (depth == limit ? movePath.size() + 1 : solve(movePath + 'a', depth + 1)));
       }
-    } while (next_permutation(movePath.begin(), movePath.end()));
+    } while (ranges::next_permutation(movePath).found);
 
     result += minLen;
     curr = next;

--- a/2024/23/b.cpp
+++ b/2024/23/b.cpp
@@ -12,7 +12,7 @@ using namespace std;
 vector<unordered_set<int>> connections;
 unordered_set<int> largestClique;
 
-void findLargestClique(unordered_set<int>& R, unordered_set<int>& P, unordered_set<int>& X) {
+void findLargestClique(const unordered_set<int>& R, unordered_set<int>& P, unordered_set<int>& X) {
   if (P.empty() && X.empty() && R.size() > largestClique.size()) {
     largestClique = R;
     return;


### PR DESCRIPTION
## Summary
- switch the day 18 solutions to the range-based overload of `std::ranges::replace`
- update day 21 solutions to use range-based sorting, permutation, and predicate checks while splitting combined declarations
- make the Bron–Kerbosch helper in day 23 take its clique parameter by const reference

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d4fc3aa60483319cde5e6356a7d495