### PR TITLE
Optimize string handling and sorting utilities

### DIFF
--- a/2024/21/a.cpp
+++ b/2024/21/a.cpp
@@ -20,7 +20,7 @@ unordered_map<char, array<int8_t, 2>> directions = {{'^', {-1, 0}}, {'v', {1, 0}
 unordered_map<string, uint64_t> cache;
 constexpr uint_fast8_t limit = 2;
 
-uint64_t solve(string path, char depth = 0) {
+uint64_t solve(const string& path, char depth = 0) {
   auto key = path + depth;
   uint64_t& result = cache[key];
   if (result) {

--- a/2024/23/b.cpp
+++ b/2024/23/b.cpp
@@ -54,7 +54,7 @@ int main() {
   unordered_map<string,int> id;
   vector<string> name;
 
-  auto getId = [&id, &name](const string& s) -> int {
+  auto getId = [&id, &name](const string& s) {
     auto [it, added] = id.try_emplace(s, (int)id.size());
     if (added) name.push_back(s);
     return it->second;
@@ -84,7 +84,7 @@ int main() {
   for (int v : largestClique) {
     result.push_back(name[v]);
   }
-  sort(result.begin(), result.end());
+  std::ranges::sort(result);
 
   std::cout << std::ranges::to<std::string>(result | std::views::join_with(',')) << std::endl;
 }


### PR DESCRIPTION
## Summary
- drop the redundant return type from the Day 23 solver's ID lookup lambda and adopt the range overload of `std::ranges::sort`
- pass the keypad path string by const reference in the Day 21 solver to avoid copying expensive data

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d666e23e648331b85e75265f55731f