### PR TITLE
Adjust guard starting coordinate assignment

### DIFF
--- a/2024/06/a.cpp
+++ b/2024/06/a.cpp
@@ -20,7 +20,8 @@ int main() {
   
   for (string line; getline(inputFile, line); map.push_back(line)) {
     if (auto pos = line.find('^'); pos != string::npos) {
-      x = pos, y = map.size();
+      x = static_cast<int>(pos);
+      y = static_cast<int>(map.size());
     }
   }
 


### PR DESCRIPTION
## Summary
- split the combined coordinate assignment for the guard's starting point into separate statements
- apply explicit int casts to the position and row count when setting the starting coordinates

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68da1dea026883318f926e0deabe0103