### PR TITLE
Fix MSVC stream output for AoC 2024 day 25

### DIFF
--- a/2024/25/a.cpp
+++ b/2024/25/a.cpp
@@ -35,5 +35,5 @@ int main() {
     return (lock & key) == 0;
   };
 
-  cout << ranges::count_if(views::cartesian_product(locks, keys), isValidPair) << endl;
+  cout << static_cast<uint64_t>(ranges::count_if(views::cartesian_product(locks, keys), isValidPair)) << endl;
 }


### PR DESCRIPTION
## Summary
- directly stream the Day 25 valid pair count as a uint64_t so MSVC handles the output without __int128 overloads

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68da23963c7c8331abfa82c808cbb87e