### PR TITLE
Fix integer conversions in 2024 day 9-11 solutions

### DIFF
--- a/2024/09/a.cpp
+++ b/2024/09/a.cpp
@@ -12,13 +12,13 @@ int main() {
   }
   vector<int> disk;
   uint64_t idx = 0;
-  uint64_t id = 0;
+  int id = 0;
   uint64_t checksum = 0;
   for (istreambuf_iterator<char> it(inputFile), end; it != end; ++it, ++idx) {
     disk.insert(disk.end(), *it - '0', idx & 1 ? -1 : id++);
   }
 
-  for (int freeIdx = 0, usedIdx = disk.size() - 1; freeIdx <= usedIdx; --usedIdx) {
+  for (int freeIdx = 0, usedIdx = static_cast<int>(disk.size()) - 1; freeIdx <= usedIdx; --usedIdx) {
     if(disk[usedIdx] != -1) {
       while (disk[freeIdx] != -1 && freeIdx <= usedIdx) {
         checksum += freeIdx * disk[freeIdx];

--- a/2024/10/a.cpp
+++ b/2024/10/a.cpp
@@ -23,8 +23,8 @@ int main() {
     }
   }
   int totalScore = 0;
-  int rows = grid.size();
-  int cols = grid[0].size();
+  int rows = static_cast<int>(grid.size());
+  int cols = static_cast<int>(grid[0].size());
   vector<vector<bool>> visited(rows, vector<bool>(cols));
   for(auto [x, y] : zeroPositions) {
     visited.assign(rows, vector<bool>(cols, false));

--- a/2024/10/b.cpp
+++ b/2024/10/b.cpp
@@ -26,8 +26,8 @@ int main() {
   }
 
   int totalWays = 0;
-  int rows = grid.size();
-  int cols = grid[0].size();
+  int rows = static_cast<int>(grid.size());
+  int cols = static_cast<int>(grid[0].size());
   vector<vector<int>> ways(rows, vector<int>(cols, 0)); // DP table to store path counts
 
   for (auto [x, y] : zeroPositions) {

--- a/2024/11/a.cpp
+++ b/2024/11/a.cpp
@@ -29,7 +29,7 @@ int main() {
         next[1] += count;
       } else if (to_string(stone).size() % 2 == 0) {
         string s = to_string(stone);
-        int mid = s.size() / 2;
+        int mid = static_cast<int>(s.size()) / 2;
         next[(uint64_t)stoll(s.substr(0, mid))] += count;
         next[(uint64_t)stoll(s.substr(mid))] += count;
       } else {


### PR DESCRIPTION
## Summary
- adjust the day 9 part A solution to use an `int` identifier and cast the disk size when computing the used index
- cast grid dimensions to `int` in the day 10 part A and B solutions
- cast the string length before splitting in the day 11 part A solution

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68da4bdc1c308331840d3d30749b8b4b