### PR TITLE
Refactor conditional logic in AoC 2024 solutions

### DIFF
--- a/2024/03/b.cpp
+++ b/2024/03/b.cpp
@@ -18,7 +18,12 @@ int main() {
   bool enable = true;
 
   for (sregex_iterator it(content.begin(), content.end(), r), end; it != end; ++it) {
-    enable = (*it).str() == "do()" ? true : (*it).str() == "don't()" ? false : enable;
+    const string command = (*it).str();
+    if (command == "do()") {
+      enable = true;
+    } else if (command == "don't()") {
+      enable = false;
+    }
     sum += enable && (*it)[1].matched ? stoi((*it)[1]) * stoi((*it)[2]) : 0;
   }
 

--- a/2024/19/a.cpp
+++ b/2024/19/a.cpp
@@ -47,7 +47,9 @@ int main() {
   
   int possible = 0;
   for (const auto &designStr : designs) {
-    possible += canFormDesign(designStr);
+    if (canFormDesign(designStr)) {
+      ++possible;
+    }
   }
   
   cout << possible << endl;

--- a/2024/24/a.cpp
+++ b/2024/24/a.cpp
@@ -26,7 +26,8 @@ int main() {
     pendingGates.pop();
 
     if (wireValues.contains(input1) && wireValues.contains(input2)) {
-      bool v1 = wireValues[input1], v2 = wireValues[input2];
+      bool v1 = wireValues[input1];
+      bool v2 = wireValues[input2];
       wireValues[output] = (op == "AND" ? v1 & v2 : op == "OR" ? v1 | v2 :  v1 ^ v2);
     } else {
       pendingGates.emplace(input1, input2, op, output);


### PR DESCRIPTION
## Summary
- separate the wire value lookups in day 24 part a for clarity
- replace aggregated boolean accumulation with explicit increment in day 19 part a
- expand the nested ternary controlling the enable flag in day 3 part b into if/else logic

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68db6dd0e48c833186c0df5c7155109a