### PR TITLE
Include 2023 directory in SonarCloud sources

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.organization=miracoli
 sonar.projectName=Advent-of-Code
 sonar.host.url=https://sonarcloud.io
 
-sonar.sources=2024
+sonar.sources=2023,2024
 sonar.inclusions=**/*.cpp
 sonar.sourceEncoding=UTF-8
 


### PR DESCRIPTION
## Summary
- include the 2023 folder alongside 2024 in the SonarCloud source configuration so it is analyzed

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68db904aaaf48331bef32db3a6612019