### PR TITLE
Fix digit search loops in 2023 Day 1 Part B

### DIFF
--- a/2023/01/b.cpp
+++ b/2023/01/b.cpp
@@ -35,12 +35,18 @@ int main() {
     int firstDigit = -1;
     int lastDigit  = -1;
 
-    for (size_t i = 0; i < line.size() && firstDigit == -1; ++i) { // left-to-right
+    for (size_t i = 0; i < line.size(); ++i) { // left-to-right
       checkAt(line, i, firstDigit);
+      if (firstDigit != -1) {
+        break;
+      }
     }
 
-    for (size_t i = line.size() - 1; i >= 0 && lastDigit == -1; --i) { // right-to-left
-      checkAt(line, i, lastDigit);
+    for (int i = static_cast<int>(line.size()) - 1; i >= 0; --i) { // right-to-left
+      checkAt(line, static_cast<size_t>(i), lastDigit);
+      if (lastDigit != -1) {
+        break;
+      }
     }
 
     if (firstDigit != -1) {


### PR DESCRIPTION
## Summary
- stop scanning once the first and last digits are found
- fix the reverse loop to avoid unsigned index underflow

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68dbb862222c8331bdb4369f928c9851