### PR TITLE
Fix minor typing issues across Advent of Code 2024 solutions

### DIFF
--- a/2024/06/b.cpp
+++ b/2024/06/b.cpp
@@ -58,10 +58,8 @@ int main() {
 
   int endlessLoopCount = 0;
 
-  for (auto cell : candidates) {
-    auto px = get<0>(cell);
-    auto py = get<1>(cell);
-    direction = get<2>(cell);
+  for (auto [px, py, dir] : candidates) {
+    direction = dir;
 
     // Start from predecessor of the obstacle cell
     x = px - dOff[1][direction];

--- a/2024/08/b.cpp
+++ b/2024/08/b.cpp
@@ -20,7 +20,7 @@ int main() {
     set<pair<int, int>> antinodes;
 
     for (string line; getline(inputFile, line); ++rows) {
-        cols = line.size();
+        cols = static_cast<int>(line.size());
         for (int x = 0; x < line.size(); ++x) {
             if (line[x] != '.') {
                 antennas[line[x]].emplace_back(x, rows);

--- a/2024/10/a.cpp
+++ b/2024/10/a.cpp
@@ -23,8 +23,8 @@ int main() {
     }
   }
   int totalScore = 0;
-  int rows = static_cast<int>(grid.size());
-  int cols = static_cast<int>(grid[0].size());
+  auto rows = static_cast<int>(grid.size());
+  auto cols = static_cast<int>(grid[0].size());
   vector<vector<bool>> visited(rows, vector<bool>(cols));
   for(auto [x, y] : zeroPositions) {
     visited.assign(rows, vector<bool>(cols, false));

--- a/2024/24/b.cpp
+++ b/2024/24/b.cpp
@@ -38,7 +38,7 @@ int main() {
   ds.resize(as.size());
   cs[1] = bs[0]; // Initialize first carry signal
 
-  auto gateSwap = [&gates, &as, &bs, &cs, &ds](const string& in1, const string& in2) {
+  auto gateSwap = [&gates, &as, &bs, &cs, &ds](const string in1, const string in2) {
     swap(gates[in2], gates[in1]);
     for (auto* vec : {&as, &bs, &cs, &ds}) {
       for (auto& output : *vec) {

--- a/2024/24/b.cpp
+++ b/2024/24/b.cpp
@@ -38,7 +38,7 @@ int main() {
   ds.resize(as.size());
   cs[1] = bs[0]; // Initialize first carry signal
 
-  auto gateSwap = [&gates, &as, &bs, &cs, &ds](const string in1, const string in2) {
+  auto gateSwap = [&gates, &as, &bs, &cs, &ds](const string& in1, const string& in2) {
     swap(gates[in2], gates[in1]);
     for (auto* vec : {&as, &bs, &cs, &ds}) {
       for (auto& output : *vec) {


### PR DESCRIPTION
## Summary
- avoid unnecessary string copies in the Day 24 gate swapping helper
- use structured bindings when iterating candidate states in Day 6
- tighten type conversions and declarations in the Day 8 and Day 10 solutions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dbe1b1c2e48331bc6a89b8d68c55c2