### PR TITLE
Fix shadowed lambda parameter in Day 20 solutions

### DIFF
--- a/2024/20/a.cpp
+++ b/2024/20/a.cpp
@@ -32,7 +32,7 @@ int main() {
   vector<int> locIndex(grid.size() * grid[0].size(), -1);
   int direction = 0;
   int idx = 0;
-  auto encode = [&grid](pair<int, int> pos) { return pos.first * grid[0].size() + pos.second; };
+  auto encode = [&grid](pair<int, int> cell) { return cell.first * grid[0].size() + cell.second; };
 
   while (grid[pos.first][pos.second] != 'E') {
     path.emplace_back(pos);

--- a/2024/20/b.cpp
+++ b/2024/20/b.cpp
@@ -32,7 +32,7 @@ int main() {
   vector<int> locIndex(grid.size() * grid[0].size(), -1);
   int direction = 0;
   int idx = 0;
-  auto encode = [&grid](pair<int, int> pos) { return pos.first * grid[0].size() + pos.second; };
+  auto encode = [&grid](pair<int, int> cell) { return cell.first * grid[0].size() + cell.second; };
 
   while (grid[pos.first][pos.second] != 'E') {
     path.emplace_back(pos);


### PR DESCRIPTION
## Summary
- rename the encode lambda parameter in day 20 parts A and B to avoid shadowing the outer position variable

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68dcc9e419948331a66abba1bca4decc