### PR TITLE
Refactor antinode direction factors into constexpr array

### DIFF
--- a/2024/08/b.cpp
+++ b/2024/08/b.cpp
@@ -4,8 +4,11 @@
 #include <map>
 #include <set>
 #include <string>
+#include <array>
 
 using namespace std;
+
+static constexpr std::array<int, 2> dirFactors{-1, 1};
 
 int main() {
     ifstream inputFile("input.txt");
@@ -33,7 +36,7 @@ int main() {
             for (size_t j = i + 1; j < positions.size(); ++j) {
                 int dx = positions[j].first - positions[i].first;
                 int dy = positions[j].second - positions[i].second;
-                for (int dir : {-1, 1}) {
+                for (int dir : dirFactors) {
                     for (int a = 0; ; ++a) {
                         pair<int, int> p = { positions[i].first + dir * a * dx, positions[i].second + dir * a * dy };
                         if (p.first >= 0 && p.second >= 0 && p.first < cols && p.second < rows) {


### PR DESCRIPTION
## Summary
- include the array header and define a reusable constexpr direction factor list
- iterate over the shared direction factor array when expanding antinode sequences

## Testing
- g++ -std=c++17 2024/08/b.cpp -o 2024/08/b
- cd 2024/08 && ./b

------
https://chatgpt.com/codex/tasks/task_b_68de0cd5d9cc8331a964937cc90d86d6