### PR TITLE
Improve Makefile for CodeQL autobuild

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+SHELL := bash
+CXX ?= g++
+CXXFLAGS ?= -std=c++23 -O2 -pipe -Wall -Wextra -pedantic -MMD -MP
+LDFLAGS ?=
+BUILD_DIR ?= build
+
+# allow overriding the searched dirs: make DIRS="2022 2023 2024"
+DIRS ?= 2023 2024
+CPP_SOURCES := $(shell find $(DIRS) -name '*.cpp' 2>/dev/null)
+BINARIES := $(CPP_SOURCES:%.cpp=$(BUILD_DIR)/%)
+
+.PHONY: all clean
+all: $(BINARIES)
+
+# one binary per .cpp
+$(BUILD_DIR)/%: %.cpp
+	@mkdir -p $(dir $@)
+	$(CXX) $(CXXFLAGS) $< -o $@ $(LDFLAGS)
+
+clean:
+	rm -rf $(BUILD_DIR)
+
+# include auto-generated dep files (safe if they don't exist yet)
+-include $(BINARIES:%=%.d)

--- a/README.md
+++ b/README.md
@@ -12,3 +12,7 @@ An overview of the line counts for all solutions is published on [GitHub Pages](
 
 The automated build runs on GitHub Actions using GCC, Clang and MSVC.
 
+## Building
+
+Run `make` from the repository root to compile every C++ solution. The resulting executables are placed in the corresponding subdirectories under `build/`. You can target specific Advent of Code years by passing `DIRS="2023 2024"` (or any other subset) to the command.
+


### PR DESCRIPTION
## Summary
- extend the Makefile with configurable directories, dependency tracking, and a fixed SHELL for consistent builds
- clarify the README build section with instructions on targeting specific Advent of Code years

## Testing
- make -j2

------
https://chatgpt.com/codex/tasks/task_b_68e12b19d8ec83318421355bb0863ae8