### PR TITLE
Fix coverage workflow permissions for artifact upload

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
+      actions: write
     env:
       GITCRYPT_KEY_B64: ${{ secrets.GITCRYPT_KEY_B64 }}
       COVERAGE_COMPILER_LABEL: gcov


### PR DESCRIPTION
## Summary
- grant the coverage workflow actions: write permissions so it can upload artifacts

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_b_68e12e262a1483319d3ef3c610fbc9d6