### PR TITLE
Ensure coverage workflow uses matching gcov version

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -79,8 +79,9 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p coverage
-          lcov --capture --directory build/$COVERAGE_COMPILER_LABEL --base-directory . --rc lcov_branch_coverage=1 --output-file coverage/lcov.info
-          lcov --remove coverage/lcov.info '/usr/*' '*/tests/*' --output-file coverage/lcov.info
+          gcov_tool=$(command -v gcov-14 || command -v gcov)
+          lcov --gcov-tool "$gcov_tool" --capture --directory build/$COVERAGE_COMPILER_LABEL --base-directory . --rc lcov_branch_coverage=1 --output-file coverage/lcov.info
+          lcov --gcov-tool "$gcov_tool" --remove coverage/lcov.info '/usr/*' '*/tests/*' --output-file coverage/lcov.info
           lcov --list coverage/lcov.info
 
       - name: Generate gcov reports (optional)


### PR DESCRIPTION
## Summary
- use the gcov tool that matches the compiler version when generating coverage data

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e12eb31fb083319c966b87b925fe91