### PR TITLE
Add --no-external flag to lcov removal step

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -82,7 +82,7 @@ jobs:
           mkdir -p coverage
           gcov_tool=$(command -v gcov-14 || command -v gcov)
           lcov --gcov-tool "$gcov_tool" --capture --directory build/$COVERAGE_COMPILER_LABEL --base-directory . --rc lcov_branch_coverage=1 --output-file coverage/lcov.info
-          lcov --gcov-tool "$gcov_tool" --remove coverage/lcov.info '/usr/*' '*/tests/*' --output-file coverage/lcov.info
+          lcov --gcov-tool "$gcov_tool" --remove coverage/lcov.info '/usr/*' '*/tests/*' --no-external --output-file coverage/lcov.info
           lcov --list coverage/lcov.info
 
       - name: Generate gcov reports (optional)


### PR DESCRIPTION
## Summary
- add the `--no-external` flag to the lcov removal step so the coverage workflow excludes external files

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_b_68e132cb56c4833192c8501d9a5e1c2c