### PR TITLE
Use GCC 14 in CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,24 +17,25 @@ jobs:
       contents: read
       security-events: write
 
-    strategy:
-      fail-fast: false
-      matrix:
-        language: [ 'cpp' ]
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Install g++-14
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y g++-14
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 100
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:
-          languages: ${{ matrix.language }}
+          languages: cpp
 
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+      - name: Build (GCC 14)
+        run: make -j"$(nproc)" CXX=g++-14
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3
         with:
-          category: '/language:${{ matrix.language }}'
+          category: '/language:cpp'


### PR DESCRIPTION
## Summary
- install GCC 14 in the CodeQL workflow
- initialize CodeQL for C++ and build using make with g++-14 prior to analysis

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e135bf9068833198217c52958007ed