### PR TITLE
Speed up CI builds with parallel make

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,13 +65,13 @@ jobs:
         if: matrix.compiler != 'cl'
         run: |
           set -e
-          for cpp in $(find . -type f \( -name 'a.cpp' -o -name 'b.cpp' \)); do
-            dir=$(dirname "$cpp")
-            base=$(basename "$cpp" .cpp)
-            out_dir="build/${{ matrix.compiler }}/$dir"
-            mkdir -p "$out_dir"
-            ${{ matrix.compiler }} -std=c++23 -Werror -O2 "$cpp" -o "$out_dir/$base"
-          done
+          make clean
+          make \
+            CXX="${{ matrix.compiler }}" \
+            BUILD_DIR="build/${{ matrix.compiler }}" \
+            CXXFLAGS="-std=c++23 -Werror -O2" \
+            DIRS="2023 2024" \
+            -j"$(nproc)"
       - name: Run all solutions
         if: runner.os != 'Windows'
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -61,13 +61,13 @@ jobs:
           set -euo pipefail
           cxx=$(command -v g++-14 || command -v g++)
           label="$COVERAGE_COMPILER_LABEL"
-          while IFS= read -r cpp; do
-            dir=$(dirname "$cpp")
-            base=$(basename "$cpp" .cpp)
-            out_dir="build/$label/$dir"
-            mkdir -p "$out_dir"
-            "$cxx" -std=c++23 -O0 -g --coverage "$cpp" -o "$out_dir/$base"
-          done < <(find 2023 2024 -type f \( -name 'a.cpp' -o -name 'b.cpp' \))
+          make clean BUILD_DIR="build/$label"
+          make \
+            CXX="$cxx" \
+            BUILD_DIR="build/$label" \
+            CXXFLAGS="-std=c++23 -O0 -g --coverage" \
+            DIRS="2023 2024" \
+            -j"$(nproc)"
 
       - name: Run solution tests
         if: steps.coverage-metadata.outputs.coverage-generated == 'true'

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -79,7 +79,6 @@ jobs:
 
       - name: Build with build-wrapper
         run: |
-          mkdir -p build
           ./build-wrapper-linux-x86/build-wrapper-linux-x86-64 --out-dir bw-output bash -c '
             set -euo pipefail
             cxx=$(command -v g++-14 || command -v g++)
@@ -88,13 +87,13 @@ jobs:
               exit 1
             fi
             "$cxx" --version
-            while IFS= read -r cpp; do
-              dir=$(dirname "$cpp")
-              base=$(basename "$cpp" .cpp)
-              out_dir="build/$dir"
-              mkdir -p "$out_dir"
-              "$cxx" -std=c++23 -O2 "$cpp" -o "$out_dir/$base"
-            done < <(find 2023 2024 -type f \( -name "a.cpp" -o -name "b.cpp" \))
+            make clean
+            make \
+              CXX="$cxx" \
+              BUILD_DIR="build" \
+              CXXFLAGS="-std=c++23 -O2" \
+              DIRS="2023 2024" \
+              -j"$(nproc)"
           '
 
       - name: SonarCloud Scan

--- a/README.md
+++ b/README.md
@@ -16,3 +16,5 @@ The automated build runs on GitHub Actions using GCC, Clang and MSVC.
 
 Run `make` from the repository root to compile every C++ solution. The resulting executables are placed in the corresponding subdirectories under `build/`. You can target specific Advent of Code years by passing `DIRS="2023 2024"` (or any other subset) to the command.
 
+For faster local builds, invoke `make -j$(nproc)` to compile the solutions in parallel.
+


### PR DESCRIPTION
## Summary
- invoke the project Makefile from the Linux C++ build jobs so gcc and clang builds use parallel compilation
- reuse the same Makefile in coverage and SonarCloud jobs for a consistent, parallelized build path
- document the faster `make -j$(nproc)` option for local builds

## Testing
- make -j"$(nproc)"


------
https://chatgpt.com/codex/tasks/task_b_68e1356ebc588331a45efdfc3310bc4a