### PR TITLE
Grant SonarCloud workflow actions write permission

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -33,6 +33,7 @@ jobs:
     name: SonarCloud
     runs-on: ubuntu-24.04
     permissions:
+      actions: write
       contents: read
       pull-requests: read
     steps:


### PR DESCRIPTION
## Summary
- grant the SonarCloud workflow the actions: write permission required for artifact downloads

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e13b25b304833191f2ad746e1a981c