### PR TITLE
Store and reuse compiled g++ artifacts for Pages deploy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,12 @@ jobs:
             CXXFLAGS="-std=c++23 -Werror -O2" \
             DIRS="2023 2024" \
             -j"$(nproc)"
+      - name: Upload g++ artifacts
+        if: matrix.compiler == 'g++' && matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: g++
+          path: build/g++/**
       - name: Run all solutions
         if: runner.os != 'Windows'
         run: |

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,9 +1,10 @@
 name: Deploy static content to Pages
 
 on:
-  push:
-    branches: ["main"]
-  workflow_dispatch:
+  workflow_run:
+    workflows: ["Build C++ solutions"]
+    types:
+      - completed
 
 permissions:
   contents: read
@@ -27,6 +28,12 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v5
+      - name: Download g++ artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: g++
+          path: build/g++
+          run-id: ${{ github.event.workflow_run.id }}
       - name: Install git-crypt
         run: sudo apt-get update && sudo apt-get install -y git-crypt
       - name: Unlock encrypted inputs
@@ -36,8 +43,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y g++-14 hyperfine jq
-          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 100
+          sudo apt-get install -y hyperfine jq
       - name: Generate index.html
         run: |
           mkdir -p site
@@ -62,21 +68,25 @@ jobs:
               b_lines=""
               a_time=""
               b_time=""
+              binary_a="build/g++/${dir}/a"
+              binary_b="build/g++/${dir}/b"
               if [ -f "$dir/a.cpp" ]; then
                 a_lines=$(wc -l < "$dir/a.cpp" | xargs)
-                (cd "$dir" && g++ -std=c++23 -O2 a.cpp -o a)
-                (cd "$dir" && hyperfine -N -u microsecond -w 50 -r 50 ./a --export-json /tmp/a.json > /dev/null)
-                a_time_raw=$(jq '.results[0].min * 1000' /tmp/a.json)
-                a_time=$(printf "%.2f" "$a_time_raw")
-                a_times+=("$a_time_raw")
+                if [ -x "$binary_a" ]; then
+                  hyperfine -N -u microsecond -w 50 -r 50 "./$binary_a" --export-json /tmp/a.json > /dev/null
+                  a_time_raw=$(jq '.results[0].min * 1000' /tmp/a.json)
+                  a_time=$(printf "%.2f" "$a_time_raw")
+                  a_times+=("$a_time_raw")
+                fi
               fi
               if [ -f "$dir/b.cpp" ]; then
                 b_lines=$(wc -l < "$dir/b.cpp" | xargs)
-                (cd "$dir" && g++ -std=c++23 -O2 b.cpp -o b)
-                (cd "$dir" && hyperfine -N -u microsecond -w 50 -r 50 ./b --export-json /tmp/b.json > /dev/null)
-                b_time_raw=$(jq '.results[0].min * 1000' /tmp/b.json)
-                b_time=$(printf "%.2f" "$b_time_raw")
-                b_times+=("$b_time_raw")
+                if [ -x "$binary_b" ]; then
+                  hyperfine -N -u microsecond -w 50 -r 50 "./$binary_b" --export-json /tmp/b.json > /dev/null
+                  b_time_raw=$(jq '.results[0].min * 1000' /tmp/b.json)
+                  b_time=$(printf "%.2f" "$b_time_raw")
+                  b_times+=("$b_time_raw")
+                fi
               fi
               echo "<tr><td>$day</td><td>${a_lines}</td><td>${b_lines}</td><td>${a_time}</td><td>${b_time}</td></tr>" >> site/index.html
             done


### PR DESCRIPTION
## Summary
- upload the Ubuntu g++ build outputs as artifacts in the C++ build workflow
- trigger the Pages deployment after the build completes and download the stored binaries
- reuse the downloaded binaries when generating the site index instead of recompiling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e13b47b16483318d43c718abb59c27