### PR TITLE
Fix SonarCloud workflow permissions

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -25,6 +25,9 @@ jobs:
     needs: secret-check
     if: ${{ needs.secret-check.outputs.has-token == 'true' }}
     uses: ./.github/workflows/coverage.yml
+    permissions:
+      actions: write
+      contents: read
     secrets: inherit
 
   analyze:


### PR DESCRIPTION
## Summary
- grant the reusable coverage workflow the actions and contents permissions it requires when called from the SonarCloud pipeline

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68e13cca3f288331822e57128b6e1eb0