### PR TITLE
Use gcov reports in SonarCloud workflow

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,4 +8,4 @@ sonar.inclusions=**/*.cpp
 sonar.sourceEncoding=UTF-8
 
 sonar.cfamily.build-wrapper-output=bw-output
-sonar.coverageReportPaths=coverage/lcov.info
+sonar.cfamily.gcov.reportsPath=coverage/gcov


### PR DESCRIPTION
## Summary
- update the SonarCloud project configuration to consume gcov coverage reports produced by the coverage workflow

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68e140aec32883318c75eb830a08f939