### PR TITLE
Add HTML coverage summary to lcov workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -85,6 +85,17 @@ jobs:
           lcov --gcov-tool "$gcov_tool" --remove coverage/lcov.info --output-file coverage/lcov.info
           lcov --list coverage/lcov.info --rc branch_coverage=1
 
+      - name: Generate HTML coverage summary
+        if: steps.coverage-metadata.outputs.coverage-generated == 'true'
+        run: |
+          set -euo pipefail
+          genhtml \
+            --branch-coverage \
+            --demangle-cpp \
+            --legend \
+            --output-directory coverage/html \
+            coverage/lcov.info
+
       - name: Generate gcov reports (optional)
         if: steps.coverage-metadata.outputs.coverage-generated == 'true'
         run: |
@@ -105,4 +116,5 @@ jobs:
           path: |
             coverage/lcov.info
             coverage/gcov
+            coverage/html
           if-no-files-found: error


### PR DESCRIPTION
## Summary
- generate an HTML report from the lcov results using genhtml
- include the generated HTML directory in the uploaded coverage artifact for easier human consumption

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_b_68e145ecf76c8331b1464084a0c5cf20