### PR TITLE
Fix workflow_run trigger definition for Pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,7 +2,8 @@ name: Deploy static content to Pages
 
 on:
   workflow_run:
-    workflows: ["Build C++ solutions"]
+    workflows:
+      - "Build C++ solutions"
     types:
       - completed
 


### PR DESCRIPTION
## Summary
- fix the GitHub Pages workflow trigger to use a multi-line workflow list entry

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e14255e1348331a3b54a97de1c7a01