### PR TITLE
Fix Pages workflow_run trigger reference

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build C++ solutions
+name: Build Cpp Solutions
 
 on:
   push:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,7 +2,7 @@ name: Deploy static content to Pages
 
 on:
   workflow_run:
-    workflows: ["Build C++ solutions"]
+    workflows: ["Build Cpp Solutions"]
     types:
       - completed
 


### PR DESCRIPTION
## Summary
- rename the build workflow to "Build Cpp Solutions" to avoid parsing issues
- point the Pages workflow_run trigger at the updated workflow name

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_b_68e14255e1348331a3b54a97de1c7a01

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Renamed the build workflow for consistency.
  * Updated the deployment workflow to trigger from the new build workflow name.
  * No changes to build or deployment behavior; end-user experience remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->