### PR TITLE
Fix Pages workflow artifact name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
         if: matrix.compiler == 'g++' && matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v4
         with:
-          name: g++
+          name: gpp-build
           path: build/g++/**
       - name: Run all solutions
         if: runner.os != 'Windows'

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Download g++ artifact
         uses: actions/download-artifact@v4
         with:
-          name: g++
+          name: gpp-build
           path: build/g++
           run-id: ${{ github.event.workflow_run.id }}
       - name: Download coverage artifact


### PR DESCRIPTION
## Summary
- rename the uploaded C++ build artifact to avoid using plus signs
- update the Pages workflow to download the renamed artifact

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68e21653c21c8331aa16f727765e28fd