### PR TITLE
Fix SonarCloud workflow secret condition

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -15,7 +15,7 @@ jobs:
     secrets: inherit
 
   analyze:
-    if: ${{ secrets.SONAR_TOKEN != '' }}
+    if: ${{ env.SONAR_TOKEN != '' }}
     needs: coverage
     name: SonarCloud
     runs-on: ubuntu-24.04
@@ -23,6 +23,8 @@ jobs:
       actions: write
       contents: read
       pull-requests: read
+    env:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -87,7 +89,7 @@ jobs:
       - name: SonarCloud Scan
         uses: SonarSource/sonarqube-scan-action@v5.0.0
         env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_TOKEN: ${{ env.SONAR_TOKEN }}
           SONAR_HOST_URL: https://sonarcloud.io
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -95,5 +97,5 @@ jobs:
         uses: SonarSource/sonarqube-quality-gate-action@v1.1.0
         timeout-minutes: 5
         env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_TOKEN: ${{ env.SONAR_TOKEN }}
           SONAR_HOST_URL: https://sonarcloud.io


### PR DESCRIPTION
## Summary
- load the SonarCloud token into a job-level environment variable
- gate the analysis job using the environment value to avoid direct secret references
- reuse the environment variable when invoking SonarCloud actions

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68e219cdfd4c833180ce073e7de9272f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized SonarCloud authentication in the CI pipeline by using a single environment variable for the analysis token across checks and scan/quality gate steps. This improves consistency, reduces configuration drift, and mitigates intermittent analysis failures. Enhances maintainability and visibility of pipeline configuration. No impact on product features or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->