### PR TITLE
Ensure Pages deploy consumes gpp artifact reliably

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
@@ -29,7 +30,7 @@ jobs:
         if: runner.os != 'Windows'
         run: sudo apt-get update && sudo apt-get install -y git-crypt
       - name: Unlock encrypted inputs
-        if: runner.os != 'Windows'
+        if: runner.os != 'Windows' && env.GITCRYPT_KEY_B64 != ''
         run: |
           echo "$GITCRYPT_KEY_B64" | base64 --decode > gitcrypt.key
           git-crypt unlock gitcrypt.key
@@ -77,7 +78,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: gpp-build
-          path: build/g++/**
+          path: build/g++
       - name: Run all solutions
         if: runner.os != 'Windows'
         run: |

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -8,7 +8,7 @@ on:
       - completed
 
 permissions:
-  actions: write          # <-- add this
+  actions: read
   contents: read
   pages: write
   id-token: write
@@ -30,17 +30,42 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      actions: read
+      contents: read
+      pages: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v5
+      - name: List artifacts for triggering run (debug)
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runId = ${{ github.event.workflow_run.id }};
+            const { data } = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: runId,
+              per_page: 100,
+            });
+            core.info(`Artifacts on run ${runId}: ` + data.artifacts.map(a => `${a.name}(expired=${a.expired})`).join(", "));
       - name: Download g++ artifact
         uses: actions/download-artifact@v4
         with:
           name: gpp-build
-          path: build/g++
+          path: .
           run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Verify expected binaries exist
+        run: |
+          set -euo pipefail
+          test -d build/g++ || { echo "::error::Missing build/g++ after download"; exit 1; }
+          ls -l build/g++/2024/01/a || { echo "::error::Missing example binary a"; exit 1; }
+          ls -l build/g++/2024/01/b || { echo "::error::Missing example binary b"; exit 1; }
       - name: Download coverage artifact
         if: needs.coverage.outputs.coverage-generated == 'true'
         uses: actions/download-artifact@v4
@@ -49,6 +74,7 @@ jobs:
       - name: Install git-crypt
         run: sudo apt-get update && sudo apt-get install -y git-crypt
       - name: Unlock encrypted inputs
+        if: env.GITCRYPT_KEY_B64 != ''
         run: |
           echo "$GITCRYPT_KEY_B64" | base64 --decode > gitcrypt.key
           git-crypt unlock gitcrypt.key


### PR DESCRIPTION
## Summary
- upload the entire build/g++ directory in the build workflow and guard git-crypt unlocking
- require successful build runs with appropriate permissions before deploying Pages
- add artifact listing, authenticated download, and binary verification to catch layout issues early

## Testing
- not run (workflow changes only)


------
https://chatgpt.com/codex/tasks/task_b_68e21e74e04c8331bbbe65ca670fd804