### PR TITLE
Fix Pages deploy artifact extraction path

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -57,9 +57,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: gpp-build
-          path: .
+          path: build/g++
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: List downloaded files (debug)
+        run: |
+          echo "Tree under build/g++:"
+          find build/g++ -maxdepth 3 -type f -printf "%p\n" | sort || true
       - name: Verify expected binaries exist
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary
- extract the gpp-build artifact directly into build/g++ so deployed jobs find binaries
- add a debug step to list the downloaded files for troubleshooting

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_b_68e22347687483319694d2931289a16c