### PR TITLE
Fix GitHub Pages timing measurement by using puzzle directories

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -138,7 +138,7 @@ jobs:
               if [ -f "$dir/a.cpp" ]; then
                 a_lines=$(wc -l < "$dir/a.cpp" | xargs)
                 if [ -x "$binary_a" ]; then
-                  hyperfine -N -u microsecond -w 50 -r 50 "./$binary_a" --export-json /tmp/a.json > /dev/null
+                  hyperfine -N -u microsecond -w 50 -r 50 "cd \"$dir\" && ../$binary_a" --export-json /tmp/a.json > /dev/null
                   a_time_raw=$(jq '.results[0].min * 1000' /tmp/a.json)
                   a_time=$(printf "%.2f" "$a_time_raw")
                   a_times+=("$a_time_raw")
@@ -147,7 +147,7 @@ jobs:
               if [ -f "$dir/b.cpp" ]; then
                 b_lines=$(wc -l < "$dir/b.cpp" | xargs)
                 if [ -x "$binary_b" ]; then
-                  hyperfine -N -u microsecond -w 50 -r 50 "./$binary_b" --export-json /tmp/b.json > /dev/null
+                  hyperfine -N -u microsecond -w 50 -r 50 "cd \"$dir\" && ../$binary_b" --export-json /tmp/b.json > /dev/null
                   b_time_raw=$(jq '.results[0].min * 1000' /tmp/b.json)
                   b_time=$(printf "%.2f" "$b_time_raw")
                   b_times+=("$b_time_raw")

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -135,10 +135,12 @@ jobs:
               b_time=""
               binary_a="build/g++/${dir}/a"
               binary_b="build/g++/${dir}/b"
+              binary_a_abs="$PWD/$binary_a"
+              binary_b_abs="$PWD/$binary_b"
               if [ -f "$dir/a.cpp" ]; then
                 a_lines=$(wc -l < "$dir/a.cpp" | xargs)
                 if [ -x "$binary_a" ]; then
-                  hyperfine -N -u microsecond -w 50 -r 50 "cd \"$dir\" && ../$binary_a" --export-json /tmp/a.json > /dev/null
+                  hyperfine -N -u microsecond -w 50 -r 50 "cd \"$dir\" && \"$binary_a_abs\"" --export-json /tmp/a.json > /dev/null
                   a_time_raw=$(jq '.results[0].min * 1000' /tmp/a.json)
                   a_time=$(printf "%.2f" "$a_time_raw")
                   a_times+=("$a_time_raw")
@@ -147,7 +149,7 @@ jobs:
               if [ -f "$dir/b.cpp" ]; then
                 b_lines=$(wc -l < "$dir/b.cpp" | xargs)
                 if [ -x "$binary_b" ]; then
-                  hyperfine -N -u microsecond -w 50 -r 50 "cd \"$dir\" && ../$binary_b" --export-json /tmp/b.json > /dev/null
+                  hyperfine -N -u microsecond -w 50 -r 50 "cd \"$dir\" && \"$binary_b_abs\"" --export-json /tmp/b.json > /dev/null
                   b_time_raw=$(jq '.results[0].min * 1000' /tmp/b.json)
                   b_time=$(printf "%.2f" "$b_time_raw")
                   b_times+=("$b_time_raw")


### PR DESCRIPTION
## Summary
- run hyperfine from within each puzzle directory so binaries can read their input files
- keep execution time statistics for both parts when inputs are available

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_b_68e2334a61c4833186cda62fcf4e06b2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to execute day-specific benchmarks from within their respective directories, improving consistency and environment parity during automated runs.
  * No changes to application features or behavior; end users are unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->