### PR TITLE
Fix Pages coverage artifact download and timing

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -75,7 +75,6 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: lcov-report
-          run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path: coverage
       - name: Restore executable bits for downloaded binaries

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -75,6 +75,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: lcov-report
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: coverage
+      - name: Restore executable bits for downloaded binaries
+        run: |
+          chmod -R u+x build/g++ || true
       - name: Install git-crypt
         run: sudo apt-get update && sudo apt-get install -y git-crypt
       - name: Unlock encrypted inputs


### PR DESCRIPTION
## Summary
- ensure the Pages workflow downloads the lcov artifact from the triggering run into the expected `coverage/` directory
- restore execute permissions on the downloaded g++ binaries so the timing measurements run

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_b_68e23c42ff288331a700b8847f9d7ef1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Improved deployment workflow reliability by parameterizing artifact retrieval for authenticated, targeted downloads.
  - Restored executable permissions on downloaded build artifacts to prevent permission-related deployment failures.
  - Streamlined pre-deploy steps to make site updates more consistent and predictable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->