### PR TITLE
Allow solution test script to handle multiple years

### DIFF
--- a/tests/run_solutions.sh
+++ b/tests/run_solutions.sh
@@ -3,36 +3,44 @@ set -euo pipefail
 
 compiler="${COMPILER:-g++}"
 
-for day in $(seq -w 1 25); do
-    dir="2024/$day"
-    solution="$dir/solution.txt"
-    if [ -f "$dir/a.cpp" ] || [ -f "$dir/b.cpp" ]; then
-        if [ ! -f "$solution" ]; then
-            echo "Missing solution file for $dir" >&2
-            exit 1
-        fi
-    else
+for year_dir in */; do
+    if [[ ! $year_dir =~ ^[0-9]{4}/$ ]]; then
         continue
     fi
 
-    if [ -f "$dir/a.cpp" ]; then
-        expected=$(sed -n '1p' "$solution")
-        output=$(cd "$dir" && ../../build/"$compiler"/"$dir"/a)
-        if [ "$output" != "$expected" ]; then
-            echo "Day $day part A failed: expected '$expected', got '$output'" >&2
-            exit 1
-        fi
-    fi
+    year=${year_dir%/}
 
-    if [ -f "$dir/b.cpp" ]; then
-        expected=$(sed -n '2p' "$solution")
-        output=$(cd "$dir" && ../../build/"$compiler"/"$dir"/b)
-        if [ "$output" != "$expected" ]; then
-            echo "Day $day part B failed: expected '$expected', got '$output'" >&2
-            exit 1
-        fi
-    fi
+    for day in $(seq -w 1 25); do
+        dir="$year/$day"
+        solution="$dir/solution.txt"
 
+        if [ -f "$dir/a.cpp" ] || [ -f "$dir/b.cpp" ]; then
+            if [ ! -f "$solution" ]; then
+                echo "Missing solution file for $dir" >&2
+                exit 1
+            fi
+        else
+            continue
+        fi
+
+        if [ -f "$dir/a.cpp" ]; then
+            expected=$(sed -n '1p' "$solution")
+            output=$(cd "$dir" && ../../build/"$compiler"/"$dir"/a)
+            if [ "$output" != "$expected" ]; then
+                echo "Year $year day $day part A failed: expected '$expected', got '$output'" >&2
+                exit 1
+            fi
+        fi
+
+        if [ -f "$dir/b.cpp" ]; then
+            expected=$(sed -n '2p' "$solution")
+            output=$(cd "$dir" && ../../build/"$compiler"/"$dir"/b)
+            if [ "$output" != "$expected" ]; then
+                echo "Year $year day $day part B failed: expected '$expected', got '$output'" >&2
+                exit 1
+            fi
+        fi
+    done
 done
 
 echo "All solution tests passed."


### PR DESCRIPTION
## Summary
- iterate over all four-digit year directories when running solution checks
- include the year in failure messages for easier troubleshooting

## Testing
- not run (requires prebuilt solution binaries)


------
https://chatgpt.com/codex/tasks/task_b_68e28a15fd4c8331b5ec7beacafa8487