### PR TITLE
Add missing input failure checks to run_solutions

### DIFF
--- a/tests/run_solutions.sh
+++ b/tests/run_solutions.sh
@@ -3,6 +3,53 @@ set -euo pipefail
 
 compiler="${COMPILER:-g++}"
 
+check_part() {
+    local part=$1
+    local solution_line=$2
+    local part_label=${part^^}
+
+    if [ ! -f "$dir/$part.cpp" ]; then
+        return
+    fi
+
+    local binary="../../build/$compiler/$dir/$part"
+    local expected
+    expected=$(sed -n "${solution_line}p" "$solution")
+    local output
+    output=$(cd "$dir" && "$binary")
+    if [ "$output" != "$expected" ]; then
+        echo "Year $year day $day part $part_label failed: expected '$expected', got '$output'" >&2
+        exit 1
+    fi
+
+    local input_file="$dir/input.txt"
+    local backup_file=""
+    if [ -f "$input_file" ]; then
+        backup_file="$dir/input.txt.missing_check"
+        if [ -e "$backup_file" ]; then
+            echo "Temporary input backup already exists for $dir" >&2
+            exit 1
+        fi
+        mv "$input_file" "$backup_file"
+    fi
+
+    local status
+    if (cd "$dir" && "$binary"); then
+        status=0
+    else
+        status=$?
+    fi
+
+    if [ -n "$backup_file" ]; then
+        mv "$backup_file" "$input_file"
+    fi
+
+    if [ "$status" -ne 1 ]; then
+        echo "Year $year day $day part $part_label expected exit status 1 when input is missing, got $status" >&2
+        exit 1
+    fi
+}
+
 for year_dir in */; do
     if [[ ! $year_dir =~ ^[0-9]{4}/$ ]]; then
         continue
@@ -23,23 +70,8 @@ for year_dir in */; do
             continue
         fi
 
-        if [ -f "$dir/a.cpp" ]; then
-            expected=$(sed -n '1p' "$solution")
-            output=$(cd "$dir" && ../../build/"$compiler"/"$dir"/a)
-            if [ "$output" != "$expected" ]; then
-                echo "Year $year day $day part A failed: expected '$expected', got '$output'" >&2
-                exit 1
-            fi
-        fi
-
-        if [ -f "$dir/b.cpp" ]; then
-            expected=$(sed -n '2p' "$solution")
-            output=$(cd "$dir" && ../../build/"$compiler"/"$dir"/b)
-            if [ "$output" != "$expected" ]; then
-                echo "Year $year day $day part B failed: expected '$expected', got '$output'" >&2
-                exit 1
-            fi
-        fi
+        check_part a 1
+        check_part b 2
     done
 done
 


### PR DESCRIPTION
## Summary
- refactor the solution runner to share the part checking logic
- ensure each solution binary exits with status 1 when input.txt is missing

## Testing
- bash -n tests/run_solutions.sh

------
https://chatgpt.com/codex/tasks/task_b_68e4046573308331b3ff5f75e28670cb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Unified per-part verification in the test runner for parts A and B.
  - Ensures consistent output comparison and correct exit status when input is missing.
  - Preserves input backup/restore during test execution.
  - Continues to skip nonexistent parts and require a solution when any part exists.

- Refactor
  - Consolidated duplicate test logic into a reusable routine for easier maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->