### PR TITLE
Ensure solutions exit with status 1 when input missing

### DIFF
--- a/2024/08/a.cpp
+++ b/2024/08/a.cpp
@@ -14,7 +14,7 @@ int main() {
     ifstream inputFile("input.txt");
     if (!inputFile) {
         cerr << "Failed to open input.txt";
-        return -1;
+        return 1;
     }
 
     map<char, vector<pair<int, int>>> antennas;

--- a/2024/08/b.cpp
+++ b/2024/08/b.cpp
@@ -14,7 +14,7 @@ int main() {
     ifstream inputFile("input.txt");
     if (!inputFile) {
         cerr << "Failed to open input.txt";
-        return -1;
+        return 1;
     }
 
     map<char, vector<pair<int, int>>> antennas;

--- a/2024/24/b.cpp
+++ b/2024/24/b.cpp
@@ -12,7 +12,7 @@ int main() {
   ifstream inf{"input.txt"};
   if (!inf) {
     cerr << "Could not open file: input.txt" << endl;
-    return 2;
+    return 1;
   }
 
   for (string line; getline(inf, line) && !line.empty(););

--- a/2024/25/a.cpp
+++ b/2024/25/a.cpp
@@ -10,7 +10,7 @@ int main() {
   ifstream file("input.txt");
   if (!file) {
     cerr << "Error opening file: input.txt" << endl;
-    exit(EXIT_FAILURE);
+    return 1;
   }
 
   vector<uint32_t> locks;


### PR DESCRIPTION
## Summary
- update days 8 and 24 to return status code 1 when input.txt is missing
- replace exit(EXIT_FAILURE) in day 25 with returning 1 for missing input.txt

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e4d711436c8331a7a946a9b11f68e3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized error exit code to 1 when the input file cannot be opened, replacing previously inconsistent values. Improves predictability for scripts and CI.

* **Refactor**
  * Switched from abrupt termination to returning an error code on file-open failure, enabling cleaner shutdown and resource cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->