### PR TITLE
Add no-exception flags to all GCC/Clang builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
           make \
             CXX="${{ matrix.compiler }}" \
             BUILD_DIR="build/${{ matrix.compiler }}" \
-            CXXFLAGS="-std=c++23 -Werror -O2" \
+            CXXFLAGS="-std=c++23 -Werror -O2 -fno-exceptions -fno-unwind-tables -fno-asynchronous-unwind-tables" \
             DIRS="2023 2024" \
             -j"$(nproc)"
       - name: Upload g++ artifacts

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -66,7 +66,7 @@ jobs:
           make \
             CXX="$cxx" \
             BUILD_DIR="build/$label" \
-            CXXFLAGS="-std=c++23 -O0 -g --coverage" \
+            CXXFLAGS="-std=c++23 -O0 -g --coverage -fno-exceptions -fno-unwind-tables -fno-asynchronous-unwind-tables" \
             DIRS="2023 2024" \
             -j"$(nproc)"
 

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -89,7 +89,7 @@ jobs:
             make \
               CXX="$cxx" \
               BUILD_DIR="build" \
-              CXXFLAGS="-std=c++23 -O2" \
+              CXXFLAGS="-std=c++23 -O2 -fno-exceptions -fno-unwind-tables -fno-asynchronous-unwind-tables" \
               DIRS="2023 2024" \
               -j"$(nproc)"
           '

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 SHELL := bash
 CXX ?= g++
-CXXFLAGS ?= -std=c++23 -O2 -pipe -Wall -Wextra -pedantic -MMD -MP -include cstdint
+CXXFLAGS ?= -std=c++23 -O2 -pipe -Wall -Wextra -pedantic -MMD -MP -include cstdint \
+    -fno-exceptions -fno-unwind-tables -fno-asynchronous-unwind-tables
 LDFLAGS ?=
 BUILD_DIR ?= build
 


### PR DESCRIPTION
## Summary
- add no-exception and unwind-table disabling flags to the default Makefile configuration
- propagate the same compiler options to CI build and coverage workflows

## Testing
- make DIRS="2024/01" -j"$(nproc)"


------
https://chatgpt.com/codex/tasks/task_b_68e5048e7d04833199d498e0fbcb7acf