### PR TITLE
Apply requested day 25 parsing changes

### DIFF
--- a/2024/25/a.cpp
+++ b/2024/25/a.cpp
@@ -38,6 +38,5 @@ int main() {
     return (lock & key) == 0;
   };
 
-  cout << static_cast<uint64_t>(ranges::count_if(views::cartesian_product(locks, keys), isValidPair))
-       << endl;
+  cout << static_cast<uint64_t>(ranges::count_if(views::cartesian_product(locks, keys), isValidPair)) << endl;
 }

--- a/2024/25/a.cpp
+++ b/2024/25/a.cpp
@@ -15,11 +15,9 @@ int main() {
 
   vector<uint32_t> locks;
   vector<uint32_t> keys;
-  for (string line; getline(file, line);) {
-    if (line.empty()) {
-      continue;
-    }
+  auto parseKeyOrLock = [&file, &locks, &keys]() {
     uint32_t packed = 0;
+    string line;
     for (size_t row = 0; row < 6 && getline(file, line); ++row) {
       for (size_t col = 0; col < 5; ++col) {
         if (line[col] == '#') {
@@ -27,7 +25,12 @@ int main() {
         }
       }
     }
-    (packed & (1 << 29) ? locks : keys).push_back(packed);
+    (packed & (1U << 29) ? locks : keys).push_back(packed);
+  };
+  for (string line; getline(file, line);) {
+    if (!line.empty()) {
+      parseKeyOrLock();
+    }
   }
 
   auto isValidPair = [](const auto& tup) {
@@ -35,5 +38,6 @@ int main() {
     return (lock & key) == 0;
   };
 
-  cout << static_cast<uint64_t>(ranges::count_if(views::cartesian_product(locks, keys), isValidPair)) << endl;
+  cout << static_cast<uint64_t>(ranges::count_if(views::cartesian_product(locks, keys), isValidPair))
+       << endl;
 }


### PR DESCRIPTION
## Summary
- update day 25 main loop to call a zero-argument `parseKeyOrLock` lambda when encountering non-empty input lines
- let the lambda read its own rows from the file stream before packing and classifying the bitmask

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68fa29f9bb2083319f7ddf6699e58a7f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization by centralizing parsing logic and enhancing line processing flow for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->